### PR TITLE
Add subcribers to the topic, change string policy to data type, add d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ module "aws_config_recorder_us_west_2" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.63 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.57.0 |
 
  ## Resources
 
@@ -141,22 +141,30 @@ module "aws_config_recorder_us_west_2" {
 | [aws_iam_role_policy_attachment.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_sns_topic.aws_config_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_policy.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
+| [aws_sns_topic_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 
  ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config | `bool` | `false` | no |
+| <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Flag to indicate whether an SNS topic should be created for notifications<br>If you want to send findings to a new SNS topic, set this to true and provide a valid configuration for subscribers<br>If you are using this module to set multiple accounts and regions, only enable the SNS topic in the aggregator account and region. | `bool` | `true` | no |
+| <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the<br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set<br>create\_iam\_role to false.<br><br>See the AWS Docs for further information:<br>http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html | `string` | `null` | no |
 | <a name="input_include_global_resource_types"></a> [include\_global\_resource\_types](#input\_include\_global\_resource\_types) | True/False to add global resources to config. Default is false | `string` | `false` | no |
 | <a name="input_input_tags"></a> [input\_tags](#input\_input\_tags) | Map of tags to apply to resources | `map(any)` | <pre>{<br>  "Developer": "StratusGrid",<br>  "Provisioner": "Terraform"<br>}</pre> | no |
 | <a name="input_log_bucket_id"></a> [log\_bucket\_id](#input\_log\_bucket\_id) | ID of bucket to log config change snapshots to | `string` | n/a | yes |
+| <a name="input_recording_mode"></a> [recording\_mode](#input\_recording\_mode) | The mode for AWS Config to record configuration changes. <br><br>recording\_frequency:<br>  The frequency with which AWS Config records configuration changes (service defaults to CONTINUOUS).<br>  - CONTINUOUS<br>  - DAILY<br><br>  You can also override the recording frequency for specific resource types.<br>recording\_mode\_override:<br>  description:<br>    A description for the override.<br>  resource\_types:<br>    A list of resource types for which AWS Config records configuration changes. For example, AWS::EC2::Instance.<br>    Refer to: https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingModeOverride.html<br>  recording\_frequency:<br>    The frequency with which AWS Config records configuration changes for the specified resource types.<br>    - CONTINUOUS<br>    - DAILY<br><br>/*<br>recording\_mode = {<br>  recording\_frequency = "DAILY"<br>  recording\_mode\_override = {<br>    description         = "Override for specific resource types"<br>    resource\_types      = ["AWS::EC2::Instance"]<br>    recording\_frequency = "CONTINUOUS"<br>  }<br>}<br>*/ | <pre>object({<br>    recording_frequency = string<br>    recording_mode_override = optional(object({<br>      description         = string<br>      resource_types      = list(string)<br>      recording_frequency = string<br>    }))<br>  })</pre> | `null` | no |
+| <a name="input_s3_key_prefix"></a> [s3\_key\_prefix](#input\_s3\_key\_prefix) | The prefix for AWS Config objects stored in the the S3 bucket. If this variable is set to null, the default, no<br>prefix will be used.<br><br>Examples:<br><br>with prefix:    {S3\_BUCKET NAME}:/{S3\_KEY\_PREFIX}/AWSLogs/{ACCOUNT\_ID}/Config/*.<br>without prefix: {S3\_BUCKET NAME}:/AWSLogs/{ACCOUNT\_ID}/Config/*. | `string` | `null` | no |
 | <a name="input_snapshot_delivery_frequency"></a> [snapshot\_delivery\_frequency](#input\_snapshot\_delivery\_frequency) | Frequency which AWS Config snapshots the configuration | `string` | `"Three_Hours"` | no |
 | <a name="input_sns_kms_key_id"></a> [sns\_kms\_key\_id](#input\_sns\_kms\_key\_id) | KMS key id for encrypting cloudtrail config recorder stream sns topic. If left empty uses SNS default AWS managed key. | `string` | `""` | no |
+| <a name="input_subscribers"></a> [subscribers](#input\_subscribers) | A map of subscription configurations for SNS topics<br><br>For more information, see:<br>https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription#argument-reference<br><br>protocol:<br>  The protocol to use. The possible values for this are: sqs, sms, lambda, application. (http or https are partially<br>  supported, see link) (email is an option but is unsupported in terraform, see link).<br>endpoint:<br>  The endpoint to send data to, the contents will vary with the protocol. (see link for more information)<br>endpoint\_auto\_confirms (Optional):<br>  Boolean indicating whether the end point is capable of auto confirming subscription e.g., PagerDuty. Default is<br>  false<br>raw\_message\_delivery (Optional):<br>  Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property). Default is false. | `map(any)` | `{}` | no |
 
  ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_aws_config_configuration_recorder_id"></a> [aws\_config\_configuration\_recorder\_id](#output\_aws\_config\_configuration\_recorder\_id) | ID of configuration recorder |
+| <a name="output_aws_iam_role_config"></a> [aws\_iam\_role\_config](#output\_aws\_iam\_role\_config) | aws\_iam\_role for config |
 | <a name="output_sns_encryption_kms_key_id"></a> [sns\_encryption\_kms\_key\_id](#output\_sns\_encryption\_kms\_key\_id) | Id of key used to encrypt sns topic |
 
  ---

--- a/config-recorder.tf
+++ b/config-recorder.tf
@@ -8,50 +8,77 @@ locals {
   sns_kms_key_id = var.sns_kms_key_id != "" ? var.sns_kms_key_id : data.aws_kms_key.sns_default.id
 }
 
-resource "aws_iam_role" "config" {
-  name = "aws-config-role-${data.aws_region.current.name}"
-  tags = local.common_tags
+data "aws_iam_policy_document" "assume_role" {
+  count = var.create_iam_role ? 1 : 0
+  statement {
+    effect = "Allow"
 
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "config.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
     }
-  ]
+
+    actions = ["sts:AssumeRole"]
+  }
 }
-POLICY
+
+resource "aws_iam_role" "config" {
+  count = var.create_iam_role ? 1 : 0
+  name  = "aws-config-role-${data.aws_region.current.name}"
+  tags  = local.common_tags
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "config" {
-  role       = aws_iam_role.config.name
+  count      = var.create_iam_role ? 1 : 0
+  provider   = aws
+  role       = aws_iam_role.config[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
 }
 
 resource "aws_config_configuration_recorder" "config" {
-  name     = "aws-config-recorder"
-  role_arn = aws_iam_role.config.arn
+  name = "aws-config-recorder"
+  # required argument, an arn of a valid role should be pass if the role is not created
+  role_arn = var.create_iam_role ? aws_iam_role.config[0].arn : var.iam_role_arn
 
   recording_group {
     all_supported                 = true
     include_global_resource_types = var.include_global_resource_types
   }
+
+  dynamic "recording_mode" {
+    for_each = var.recording_mode != null ? [1] : []
+    content {
+      recording_frequency = var.recording_mode.recording_frequency
+      dynamic "recording_mode_override" {
+        for_each = var.recording_mode.recording_mode_override != null ? [1] : []
+        content {
+          description         = var.recording_mode.recording_mode_override.description
+          resource_types      = var.recording_mode.recording_mode_override.resource_types
+          recording_frequency = var.recording_mode.recording_mode_override.recording_frequency
+        }
+      }
+    }
+  }
 }
 
 resource "aws_config_delivery_channel" "config" {
+  provider       = aws
   name           = "aws-config-delivery-channel"
   s3_bucket_name = var.log_bucket_id
-  s3_key_prefix  = "config"
-  sns_topic_arn  = aws_sns_topic.aws_config_stream.arn
+  # To maintain bakcward compatibility with the previous version
+  s3_key_prefix = var.s3_key_prefix != null ? var.s3_key_prefix : "config"
+  sns_topic_arn = var.create_sns_topic == true ? aws_sns_topic.aws_config_stream[0].arn : ""
 
-  snapshot_delivery_properties {
-    delivery_frequency = var.snapshot_delivery_frequency
+  dynamic "snapshot_delivery_properties" {
+    # To maintain bakcward compatibility with the previous version the default value of snapshot_delivery_frequency where leave as is
+    for_each = var.snapshot_delivery_frequency != null && var.snapshot_delivery_frequency != "" ? [1] : []
+
+    content {
+      delivery_frequency = var.snapshot_delivery_frequency
+    }
+
   }
 
   depends_on = [aws_config_configuration_recorder.config]
@@ -66,12 +93,15 @@ resource "aws_config_configuration_recorder_status" "config" {
 
 #tfsec:ignore:aws-sns-enable-topic-encryption -- Ignores error on Turning on SNS Topic encryption.
 resource "aws_sns_topic" "aws_config_stream" {
+  count = var.create_sns_topic ? 1 : 0
+
   name              = "aws-config-stream-${data.aws_region.current.name}"
   kms_master_key_id = local.sns_kms_key_id
   tags              = local.common_tags
 }
 
 data "aws_iam_policy_document" "config_sns" {
+  count = var.create_sns_topic ? 1 : 0
   statement {
     actions = [
       "sns:Publish",
@@ -83,7 +113,7 @@ data "aws_iam_policy_document" "config_sns" {
       type = "Service"
     }
     resources = [
-      aws_sns_topic.aws_config_stream.arn,
+      aws_sns_topic.aws_config_stream[0].arn,
     ]
     sid = "ConfigSNSPolicy"
   }
@@ -106,13 +136,33 @@ data "aws_iam_policy_document" "config_sns" {
       type = "AWS"
     }
     resources = [
-      aws_sns_topic.aws_config_stream.arn,
+      aws_sns_topic.aws_config_stream[0].arn,
     ]
     sid = "DenyUnsecuredTransport"
   }
 }
 
 resource "aws_sns_topic_policy" "config" {
-  arn    = aws_sns_topic.aws_config_stream.arn
-  policy = data.aws_iam_policy_document.config_sns.json
+  count  = var.create_sns_topic ? 1 : 0
+  arn    = aws_sns_topic.aws_config_stream[0].arn
+  policy = data.aws_iam_policy_document.config_sns[0].json
+}
+
+resource "aws_sns_topic_subscription" "this" {
+  for_each = local.conditional_subscribers
+
+  topic_arn = aws_sns_topic.aws_config_stream[0].arn
+
+
+  protocol               = lookup(each.value, "protocol")
+  endpoint               = lookup(each.value, "endpoint")
+  endpoint_auto_confirms = lookup(each.value, "endpoint_auto_confirms", false)
+  raw_message_delivery   = lookup(each.value, "raw_message_delivery", false)
+
+}
+
+
+locals {
+  # Conditionally create a map of subscribers if the topic is created
+  conditional_subscribers = var.create_sns_topic ? { for key, value in var.subscribers : key => value } : {}
 }

--- a/inputs.tf
+++ b/inputs.tf
@@ -12,6 +12,43 @@
 #   default = ""
 # }
 
+variable "create_iam_role" {
+  description = "Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config"
+  type        = bool
+  default     = false
+}
+
+variable "create_sns_topic" {
+  description = <<-DOC
+    Flag to indicate whether an SNS topic should be created for notifications
+    If you want to send findings to a new SNS topic, set this to true and provide a valid configuration for subscribers
+    If you are using this module to set multiple accounts and regions, only enable the SNS topic in the aggregator account and region.
+  DOC
+  type        = bool
+  default     = true
+}
+
+variable "iam_role_arn" {
+  description = <<-DOC
+    The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the
+    AWS resources associated with the account. This is only used if create_iam_role is false.
+
+    If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set
+    create_iam_role to false.
+
+    See the AWS Docs for further information:
+    http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html
+  DOC
+  default     = null
+  type        = string
+}
+
+variable "include_global_resource_types" {
+  description = "True/False to add global resources to config. Default is false"
+  type        = string
+  default     = false
+}
+
 variable "input_tags" {
   description = "Map of tags to apply to resources"
   type        = map(any)
@@ -26,20 +63,93 @@ variable "log_bucket_id" {
   type        = string
 }
 
+variable "recording_mode" {
+  description = <<-DOC
+    The mode for AWS Config to record configuration changes. 
+
+    recording_frequency:
+      The frequency with which AWS Config records configuration changes (service defaults to CONTINUOUS).
+      - CONTINUOUS
+      - DAILY
+
+      You can also override the recording frequency for specific resource types.
+    recording_mode_override:
+      description:
+        A description for the override.
+      resource_types:
+        A list of resource types for which AWS Config records configuration changes. For example, AWS::EC2::Instance.
+        Refer to: https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingModeOverride.html
+      recording_frequency:
+        The frequency with which AWS Config records configuration changes for the specified resource types.
+        - CONTINUOUS
+        - DAILY
+
+    /*
+    recording_mode = {
+      recording_frequency = "DAILY"
+      recording_mode_override = {
+        description         = "Override for specific resource types"
+        resource_types      = ["AWS::EC2::Instance"]
+        recording_frequency = "CONTINUOUS"
+      }
+    }
+    */
+  DOC
+  type = object({
+    recording_frequency = string
+    recording_mode_override = optional(object({
+      description         = string
+      resource_types      = list(string)
+      recording_frequency = string
+    }))
+  })
+  default = null
+}
+
+variable "s3_key_prefix" {
+  type        = string
+  description = <<-DOC
+    The prefix for AWS Config objects stored in the the S3 bucket. If this variable is set to null, the default, no
+    prefix will be used.
+
+    Examples:
+
+    with prefix:    {S3_BUCKET NAME}:/{S3_KEY_PREFIX}/AWSLogs/{ACCOUNT_ID}/Config/*.
+    without prefix: {S3_BUCKET NAME}:/AWSLogs/{ACCOUNT_ID}/Config/*.
+  DOC
+  default     = null
+}
+
 variable "snapshot_delivery_frequency" {
   description = "Frequency which AWS Config snapshots the configuration"
   type        = string
   default     = "Three_Hours"
 }
 
-variable "include_global_resource_types" {
-  description = "True/False to add global resources to config. Default is false"
-  type        = string
-  default     = false
-}
-
 variable "sns_kms_key_id" {
   description = "KMS key id for encrypting cloudtrail config recorder stream sns topic. If left empty uses SNS default AWS managed key."
   type        = string
   default     = ""
+}
+
+variable "subscribers" {
+  type        = map(any)
+  description = <<-DOC
+    A map of subscription configurations for SNS topics
+
+    For more information, see:
+    https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription#argument-reference
+
+    protocol:
+      The protocol to use. The possible values for this are: sqs, sms, lambda, application. (http or https are partially
+      supported, see link) (email is an option but is unsupported in terraform, see link).
+    endpoint:
+      The endpoint to send data to, the contents will vary with the protocol. (see link for more information)
+    endpoint_auto_confirms (Optional):
+      Boolean indicating whether the end point is capable of auto confirming subscription e.g., PagerDuty. Default is
+      false
+    raw_message_delivery (Optional):
+      Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property). Default is false.
+  DOC
+  default     = {}
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "sns_encryption_kms_key_id" {
   description = "Id of key used to encrypt sns topic"
   value       = local.sns_kms_key_id
 }
+
+output "aws_iam_role_config" {
+  description = "aws_iam_role for config"
+  value       = var.create_iam_role ? aws_iam_role.config[0].arn : null
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.63"
+      version = ">= 5.57.0"
     }
   }
 }


### PR DESCRIPTION


## Change description

> Add subscribers to the topic, change string policy to data type, add a dynamic block for more arguments
For Benevity, we require the following
- Conditionally create or not IAM role used for Config, when we deploy account-wide (multiple regions), only one role is required
- Allow to pass existing role to AWS Config record
- Add a subscription to the created SNS topic
- Create SNS topic conditionally
- Allow recording mode configuration
- modify deliver frequency

Other PR will be open with the addition of an aggregator configuration

## Type of change
- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)

## Related issues

> https://stratusgrid.atlassian.net/browse/BENEVIGOV-30

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
